### PR TITLE
chore: align DSH plugin dependency and README requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,68 @@ Skills are invoked with `$skill-name`. ZCode also auto-discovers from `.claude/s
 - DeepSeek Harness (dsh): dev preview — verified on mainline 2026-08-14 (gate bundle loaded and injected in-session)
 - No external dependencies
 
+## Configuration
+
+In DeepSeek Harness, the bundle accepts a small configuration object:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `true` | Set to `false` to disable the session-start gate injection. |
+| `gateContent` | string | built-in gate text | Override the text injected into the first model step. |
+
+To change it, override the row by id in your profile's `cordis.patch.yml`:
+
+```yaml
+- insert:
+    - id: embedded-workbench
+      name: 'embedded-workbench'
+      config:
+        enabled: true
+        gateContent: |
+          ...
+```
+
+## Uninstall
+
+- If you installed through the DSH plugin manager, remove the `embedded-workbench` plugin from the target profile using the same manager you used to install it.
+- If you copied `skills/*` manually, delete the copied skill directories from `~/.agents/skills/` or the project `.dsh/skills/`.
+- If you added the bundle as a `cordis.patch.yml` row, remove the row with `id: embedded-workbench` from the profile patch and restart DSH.
+
+## Permissions & Data
+
+- The plugin runtime reads only the `skills/` directory shipped inside the package, in order to register skills through DSH's standard filesystem skill provider.
+- It injects the configured gate text into the first model step of a session.
+- It does not read credentials, open network connections, or access user data outside the DSH session context.
+- When the skills are actually used, the model may read project files as directed by the user, just like any other coding skill.
+
+## Troubleshooting
+
+- Skills not visible in DSH: confirm you are on a DSH version that supports `ctx.skills`/Agent Skills discovery, and restart the profile after install.
+- Gate not injected: check that `enabled` is not `false` and that the row id `embedded-workbench` is present in the active profile patch.
+- Plugin manager rejects installation: make sure `@deepseek-ai/*` packages are declared as `peerDependencies`, not regular `dependencies`.
+- After manual copy, DSH still doesn't see the skills: use the native bundle install (`dsh plugin add "github:AmethystLuna/embedded-workbench"`) instead of copying.
+
+## Development
+
+```bash
+npm install
+npm run typecheck
+npm run build
+```
+
+Run the DSH skills registration test and trigger tests:
+
+```bash
+node tests/dsh-skills-registration.test.mjs
+bash tests/skill-triggering/run-all.sh
+```
+
+## License & Security
+
+Licensed under MIT. See [LICENSE](LICENSE).
+
+To report a security vulnerability, do **not** open a public issue. Use the private Security Advisory path or the contact method in [SECURITY.md](SECURITY.md).
+
 ## Other Plugins Recommended
 
 | Plugin | Description |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,6 +174,68 @@ cp -r embedded-workbench/skills/* .zcode/skills/
 - DeepSeek Harness (dsh): dev preview — 已实测 mainline 2026-08-14（gate bundle 加载并注入会话成功）
 - 无外部依赖
 
+## 配置
+
+在 DeepSeek Harness 中，bundle 支持以下配置：
+
+| 键 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `enabled` | boolean | `true` | 设为 `false` 可关闭会话开始时的 gate 注入。 |
+| `gateContent` | string | 内置 gate 文本 | 覆盖注入到首轮模型上下文中的文本。 |
+
+在 profile 的 `cordis.patch.yml` 中按 row id 覆盖：
+
+```yaml
+- insert:
+    - id: embedded-workbench
+      name: 'embedded-workbench'
+      config:
+        enabled: true
+        gateContent: |
+          ...
+```
+
+## 卸载
+
+- 如果通过 DSH 插件管理器安装，请使用同一管理器从目标 profile 中移除 `embedded-workbench`。
+- 如果手动复制过 `skills/*`，请删除复制到 `~/.agents/skills/` 或项目 `.dsh/skills/` 下的对应目录。
+- 如果通过 `cordis.patch.yml` 添加，请删除 profile patch 中 `id: embedded-workbench` 对应的行，并重启 DSH。
+
+## 权限与数据
+
+- 插件运行时只读取包内自带的 `skills/` 目录，用于通过 DSH 标准 filesystem skill provider 注册技能。
+- 它会在会话首轮向模型上下文注入配置好的 gate 文本。
+- 它不读取凭据、不发起网络连接，也不会访问 DSH 会话上下文之外的用户数据。
+- 实际使用技能时，模型会像使用其他编码技能一样，按用户指示读取项目文件。
+
+## 故障排查
+
+- 技能在 DSH 中不可见：确认 DSH 版本支持 `ctx.skills` / Agent Skills 发现，并在安装后重启 profile。
+- Gate 未注入：检查 `enabled` 是否为 `false`，以及 profile patch 中是否存在 `id: embedded-workbench` 的行。
+- 插件管理器拒绝安装：确认 `@deepseek-ai/*` 包声明在 `peerDependencies` 中，而不是 `dependencies`。
+- 手动复制后 DSH 仍看不到技能：改用原生 bundle 安装（`dsh plugin add "github:AmethystLuna/embedded-workbench"`）。
+
+## 开发
+
+```bash
+npm install
+npm run typecheck
+npm run build
+```
+
+运行 DSH 技能注册测试和触发测试：
+
+```bash
+node tests/dsh-skills-registration.test.mjs
+bash tests/skill-triggering/run-all.sh
+```
+
+## 许可证与安全
+
+本项目使用 MIT 许可证，见 [LICENSE](LICENSE)。
+
+如发现安全漏洞，请**不要**公开创建 issue，应使用 GitHub Security Advisory 或 [SECURITY.md](SECURITY.md) 中的联系方式私下报告。
+
 ## 其他插件推荐
 
 | 插件 | 简介 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,13 @@
 {
     "name": "embedded-workbench",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "embedded-workbench",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "license": "MIT",
-            "dependencies": {
-                "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.6",
-                "@deepseek-ai/schemastery": "^3.18.1"
-            },
             "devDependencies": {
                 "@deepseek-ai/cordis": "^4.0.1",
                 "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
@@ -21,7 +17,9 @@
                 "@deepseek-ai/dsh-scope": "^0.1.0-rc.6",
                 "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
                 "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
+                "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.6",
                 "@deepseek-ai/dsh-timeout": "^0.0.1-rc.1",
+                "@deepseek-ai/schemastery": "^3.18.1",
                 "@types/node": "^20.0.0",
                 "typescript": "^5.0.0"
             },
@@ -29,7 +27,9 @@
                 "@deepseek-ai/cordis": "^4.0.1",
                 "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
                 "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-                "@deepseek-ai/dsh-session": "^0.0.1-rc.1"
+                "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
+                "@deepseek-ai/dsh-skill-filesystem": "^0.1.0-rc.6",
+                "@deepseek-ai/schemastery": "^3.18.1"
             }
         },
         "node_modules/@deepseek-ai/cordis": {
@@ -62,6 +62,7 @@
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
             "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@deepseek-ai/dsh-agent": {
@@ -176,6 +177,7 @@
             "version": "0.1.0-rc.6",
             "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.0-rc.6.tgz",
             "integrity": "sha512-NCgz8lCAdvd0oSGIF0EKg1OXfIC7x9r0an7mgC19F0DGzYZJe5ve6AwEYpSvKITE3V8W4NbUzLKyyZG3VH5QtQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@deepseek-ai/schemastery": "^3.18.1",
@@ -205,6 +207,7 @@
             "version": "3.18.1",
             "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
             "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@deepseek-ai/cosmokit": "^1.8.2",
@@ -215,6 +218,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -231,6 +235,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "readdirp": "^5.0.0"
@@ -246,6 +251,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
             "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 20.19.0"
@@ -280,6 +286,7 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -28,15 +28,14 @@
                     "build":  "tsc -p tsconfig.json",
                     "typecheck":  "tsc -p tsconfig.json --noEmit"
                 },
-    "dependencies":  {
-                         "@deepseek-ai/dsh-skill-filesystem":  "^0.1.0-rc.6",
-                         "@deepseek-ai/schemastery":  "^3.18.1"
-                     },
+    "dependencies":  {},
     "peerDependencies":  {
                              "@deepseek-ai/cordis":  "^4.0.1",
                              "@deepseek-ai/dsh-agent":  "^0.1.0-rc.6",
                              "@deepseek-ai/dsh-llm":  "^0.0.1-rc.1",
-                             "@deepseek-ai/dsh-session":  "^0.0.1-rc.1"
+                             "@deepseek-ai/dsh-session":  "^0.0.1-rc.1",
+                             "@deepseek-ai/dsh-skill-filesystem":  "^0.1.0-rc.6",
+                             "@deepseek-ai/schemastery":  "^3.18.1"
                          },
     "devDependencies":  {
                              "@deepseek-ai/cordis":  "^4.0.1",
@@ -47,6 +46,8 @@
                              "@deepseek-ai/dsh-scope":  "^0.1.0-rc.6",
                              "@deepseek-ai/dsh-session":  "^0.0.1-rc.1",
                              "@deepseek-ai/dsh-skill":  "^0.1.0-rc.6",
+                             "@deepseek-ai/dsh-skill-filesystem":  "^0.1.0-rc.6",
+                             "@deepseek-ai/schemastery":  "^3.18.1",
                              "@deepseek-ai/dsh-timeout":  "^0.0.1-rc.1",
                              "@types/node":  "^20.0.0",
                              "typescript":  "^5.0.0"


### PR DESCRIPTION
## 改动内容

- 将 `@deepseek-ai/dsh-skill-filesystem` 和 `@deepseek-ai/schemastery` 从 `dependencies` 移到 `peerDependencies`，避免 DSH 插件管理器质量门拒绝安装。
- 同时在 `devDependencies` 中补充这两个包，保证本地 `npm run typecheck` / `npm run build` 可运行。
- 按上游 `awesome-dsh-plugins` README 规范补齐 README 章节：
  - Configuration
  - Uninstall
  - Permissions & Data
  - Troubleshooting
  - Development
  - License & Security
- 同步更新 README.zh-CN.md 与 package-lock.json。

## 自检

- `npm run typecheck` 通过
- `npm run build` 通过
- 包名和仓库名保持原样，未做重命名。
