### PR TITLE
chore: use scoped @amethystluna package names in DSH patch and release docs

### DIFF
--- a/.dsh/INSTALL.md
+++ b/.dsh/INSTALL.md
@@ -42,7 +42,7 @@ To change the gate text or disable injection, override the row by id in your pro
 ```yaml
 - insert:
     - id: embedded-workbench
-      name: 'embedded-workbench'
+      name: '@amethystluna/embedded-workbench'
       config:
         enabled: true
         gateContent: |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To change it, override the row by id in your profile's `cordis.patch.yml`:
 ```yaml
 - insert:
     - id: embedded-workbench
-      name: 'embedded-workbench'
+      name: '@amethystluna/embedded-workbench'
       config:
         enabled: true
         gateContent: |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -188,7 +188,7 @@ cp -r embedded-workbench/skills/* .zcode/skills/
 ```yaml
 - insert:
     - id: embedded-workbench
-      name: 'embedded-workbench'
+      name: '@amethystluna/embedded-workbench'
       config:
         enabled: true
         gateContent: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,7 +41,7 @@ Shipping checklist for this plugin across the DeepSeek Harness (dsh) ecosystem a
 
 - [ ] `npm login`
 - [ ] `npm publish` from the repository root (publish whitelist: `lib/`, `src/`, `skills/`, `cordis.patch.yml`; the root package is the dsh bundle)
-- [ ] Verify: `dsh plugin --profile scratch add embedded-workbench` → `--dump-config` shows the row
+- [ ] Verify: `dsh plugin --profile scratch add @amethystluna/embedded-workbench` → `--dump-config` shows the row
 - [ ] Developer preview policy: prefer publishing a fixed version over `npm unpublish`/`npm deprecate` for broken releases
 
 ## 3. Real-profile trial (end-to-end, requires restarting the target profile)

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -6,6 +6,6 @@
 
 - insert:
     - id: embedded-workbench
-      name: 'embedded-workbench'
+      name: '@amethystluna/embedded-workbench'
       config:
         enabled: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "embedded-workbench",
+    "name": "@amethystluna/embedded-workbench",
     "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "embedded-workbench",
+            "name": "@amethystluna/embedded-workbench",
             "version": "0.7.0",
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name":  "embedded-workbench",
+    "name":  "@amethystluna/embedded-workbench",
     "version": "0.7.0",
     "description":  "Embedded C/C++ firmware development toolbox — 4 agents, 7 skills covering FreeRTOS, ISR, NVM storage, Keil MDK, ARMCLANG, HardFault, state machines, architecture, and LVGL patterns. Ships a native DeepSeek Harness (dsh) bundle that injects the session-start gate into the first model step.",
     "type":  "module",


### PR DESCRIPTION
## 改动内容

- 将 npm 包名从 `logicprobe` / `embedded-workbench` 改为 `@amethystluna/logicprobe` / `@amethystluna/embedded-workbench`。
- 同步更新：
  - `package.json`
  - `package-lock.json`
  - `cordis.patch.yml` 中的 row `name`
  - `.dsh/INSTALL.md`
  - `README.md` / `README.zh-CN.md` 中的配置示例
  - `RELEASE.md` 中的 npm 包安装命令

## 说明

- 仓库名保持不变。
- 平台插件名（Claude / Codex / Cursor / Kimi 等 manifest 中的 `name`）保持短名不变，因为这些生态的插件标识不依赖 npm scope。
- DSH 的 `cordis.patch.yml` row `name` 使用 scoped 包名，以便通过 profile 的 `node_modules` 正确解析。

## 自检

- `npm run typecheck` 通过
- `npm run build` 通过
