### PR TITLE
chore: add dsh.category and dsh.displayName metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
                   "cordis.patch.yml"
               ],
     "dsh":  {
+                "category":  "extension",
+                "displayName":  "嵌入式工作台",
                 "bundle":  {
                                "patch":  "./cordis.patch.yml"
                            }


### PR DESCRIPTION
## 改动内容

在 `package.json` 的 `dsh` 字段中补充市场/画廊元数据：

- `dsh.category`：`"extension"`
- `dsh.displayName`：中文展示名称

用于避免市场卡片直接展示原始包名，并显式声明业务分类。

## 自检

- `npm run typecheck` 通过
- `npm run build` 通过
